### PR TITLE
Fixed a bug in the save() method

### DIFF
--- a/libraries/basic_crud_model.php
+++ b/libraries/basic_crud_model.php
@@ -72,7 +72,7 @@ class BasicCRUDModel {
 			
 			$sql = "UPDATE {$this->table}"
 				 . " SET {$update_field_string}"
-				 . " WHERE id = ?";
+				 . " WHERE {$this->pkid} = ?";
 			$vals[] = intval($id); //force integer type, otherwise ADODB escapes it as a string
 			$this->db->Execute($sql, $vals);
 			return $id;


### PR DESCRIPTION
Custom class override of primary key id was not being honored in parent
save() function.
