### PR TITLE
Save & Add New + Save & Duplicate

### DIFF
--- a/packages/automobiles/controllers/dashboard/automobiles/cars.php
+++ b/packages/automobiles/controllers/dashboard/automobiles/cars.php
@@ -52,8 +52,13 @@ class DashboardAutomobilesCarsController extends CrudController {
 		if ($result == 'success') {
 			$id = $model->save($_POST);
 			$this->flash('Car Saved!');
-			$this->redirect("view?body_type={$_POST['body_type_id']}");
-		
+			if($_POST['save']) { //only redirect to list if save is clicked
+				$this->redirect("view?body_type={$_POST['body_type_id']}");
+			} elseif ($_POST['add-new']) {
+				$this->redirect("add/{$_POST['body_type_id']}");
+			} elseif ($_POST['duplicate']) { //sets colors for duplicated item, but continues script
+				$this->set('colors', ColorModel::factory()->getAllWithCar($id)); //populate the 'colors' checkbox list with previous choices checked
+			}		
 		
 		//form was submitted with invalid data -- display errors and repopulate form fields with user's submitted data...
 		} else if ($result == 'error') {
@@ -93,7 +98,8 @@ class DashboardAutomobilesCarsController extends CrudController {
 		}
 		
 		//now populate data that is the same regardless of the action taken...
-		$this->set('id', $id);
+		//if duplicating data, force this to be empty
+		$this->set('id', ($_POST['duplicate'] ? null: $id));
 		$this->set('body_type_options', BodyTypeModel::factory()->getSelectOptions(array(0 => '&lt;Choose One&gt;')));
 		$this->set('manufacturer_options', ManufacturerModel::factory()->getSelectOptions(array(0 => '&lt;Choose One&gt;')));
 		$this->set('currency_symbol', Package::getByHandle('automobiles')->config('currency_symbol'));

--- a/packages/automobiles/controllers/dashboard/automobiles/misc.php
+++ b/packages/automobiles/controllers/dashboard/automobiles/misc.php
@@ -56,7 +56,11 @@ class DashboardAutomobilesMiscController extends CrudController {
 		if ($result == 'success') {
 			$id = $model->save($_POST);
 			$this->flash('Body Type Saved!');
-			$this->redirect('body_types_list');
+			if($_POST['save']) { //only redirect to list if save is clicked
+				$this->redirect('body_types_list');
+			} elseif ($_POST['add-new']) {
+				$this->redirect('body_types_add');
+			}
 		
 		
 		//form was submitted with invalid data -- display errors and repopulate form fields with user's submitted data...
@@ -157,7 +161,11 @@ class DashboardAutomobilesMiscController extends CrudController {
 		if ($result == 'success') {
 			$id = $model->save($_POST);
 			$this->flash('Color Saved!');
-			$this->redirect('colors_list');
+			if($_POST['save']) { //only redirect to list if save is clicked
+				$this->redirect('colors_list');
+			} elseif ($_POST['add-new']) {
+				$this->redirect('color_add');
+			} //No else here in case the user is duplicating items
 		
 		
 		//form was submitted with invalid data -- display errors and repopulate form fields with user's submitted data...
@@ -188,7 +196,8 @@ class DashboardAutomobilesMiscController extends CrudController {
 		}
 		
 		//now populate data that is the same regardless of the action taken...
-		$this->set('id', $id);
+		//if duplicating data, force this to be empty
+		$this->set('id', ($_POST['duplicate'] ? null:$id));
 		
 		//finally, display the form with the data we populated above
 		$this->render('colors/edit');
@@ -250,7 +259,12 @@ class DashboardAutomobilesMiscController extends CrudController {
 		if ($result == 'success') {
 			$id = $model->save($_POST);
 			$this->flash('Manufacturer Saved!');
-			$this->redirect('manufacturers_list');
+			if($_POST['save']) { //only redirect to list if save is clicked
+				$this->redirect('manufacturers_list');
+			} elseif ($_POST['add-new']) {
+				$this->redirect('manufacturer_add');
+			} //No else here in case the user is duplicating items
+			
 		
 		
 		//form was submitted with invalid data -- display errors and repopulate form fields with user's submitted data...
@@ -281,7 +295,8 @@ class DashboardAutomobilesMiscController extends CrudController {
 		}
 		
 		//now populate data that is the same regardless of the action taken...
-		$this->set('id', $id);
+		//if duplicating data, force this to be empty
+		$this->set('id', ($_POST['duplicate'] ? null:$id));
 		
 		$this->set('country_options', array(
 			'' => '&lt;Choose One&gt;',

--- a/packages/automobiles/single_pages/dashboard/automobiles/cars/edit.php
+++ b/packages/automobiles/single_pages/dashboard/automobiles/cars/edit.php
@@ -16,7 +16,7 @@ $action = $is_new ? $this->action('add', $body_type_id) : $this->action('edit', 
 
 	<form method="post" action="<?=$action?>">
 		<?=$token?>
-		<?=$form->hidden('id', (int)$id); /* redundant, but simplifies processing */ ?>
+		<input type="hidden" id="id" name="id" value="<?= (int)$id?>" /><?php /* redundant, but simplifies processing */ /*manual hidden, since C5 overrides with post values */ ?>
 		
 		<div class="ccm-pane-body">
 
@@ -103,7 +103,9 @@ $action = $is_new ? $this->action('add', $body_type_id) : $this->action('edit', 
 		</div>
 		
 		<div class="ccm-pane-footer">
-			<?=$ih->submit(t('Save'), false, 'right', 'primary')?>
+			<?=$form->submit('duplicate','Save & Duplicate',array('class'=>'ccm-button-v2-right'))?>
+			<?=$form->submit('add-new','Save & Add New',array('class'=>'ccm-button-v2-right'))?>
+			<?=$form->submit('save','Save',array('class'=>'ccm-button-v2-right primary'))?>
 			<?=$ih->button(t('Cancel'), $this->action("view?body_type={$body_type_id}"), 'left')?>
 		</div>
 

--- a/packages/automobiles/single_pages/dashboard/automobiles/misc/body_types/edit.php
+++ b/packages/automobiles/single_pages/dashboard/automobiles/misc/body_types/edit.php
@@ -13,7 +13,7 @@ $action = $is_new ? $this->action('body_types_add') : $this->action('body_types_
 
 	<form method="post" action="<?=$action?>">
 		<?=$token?>
-		<?=$form->hidden('id', (int)$id); /* redundant, but simplifies processing */ ?>
+		<input type="hidden" id="id" name="id" value="<?= (int)$id?>" /><?php /* redundant, but simplifies processing */ /*manual hidden, since C5 overrides with post values */ ?>
 		
 		<div class="ccm-pane-body">
 			<table class="form-table">
@@ -31,7 +31,8 @@ $action = $is_new ? $this->action('body_types_add') : $this->action('body_types_
 		</div>
 		
 		<div class="ccm-pane-footer">
-			<?=$ih->submit('Save', false, 'right', 'primary')?>
+			<?=$form->submit('add-new','Save & Add New',array('class'=>'ccm-button-v2-right'))?>
+			<?=$form->submit('save','Save',array('class'=>'ccm-button-v2-right primary'))?>
 			<?=$ih->button('Cancel', $this->action('body_types_list'), 'left')?>
 		</div>
 	</form>

--- a/packages/automobiles/single_pages/dashboard/automobiles/misc/colors/edit.php
+++ b/packages/automobiles/single_pages/dashboard/automobiles/misc/colors/edit.php
@@ -13,7 +13,7 @@ $action = $is_new ? $this->action('colors_add') : $this->action('colors_edit', (
 
 	<form method="post" action="<?=$action?>">
 		<?=$token?>
-		<?=$form->hidden('id', (int)$id); /* redundant, but simplifies processing */ ?>
+		<input type="hidden" id="id" name="id" value="<?= (int)$id?>" /><?php /* redundant, but simplifies processing */ /*manual hidden, since C5 overrides with post values */ ?>
 		
 		<div class="ccm-pane-body">
 			<table class="form-table">
@@ -25,7 +25,9 @@ $action = $is_new ? $this->action('colors_add') : $this->action('colors_edit', (
 		</div>
 		
 		<div class="ccm-pane-footer">
-			<?=$ih->submit('Save', false, 'right', 'primary')?>
+			<?=$form->submit('duplicate','Save & Duplicate',array('class'=>'ccm-button-v2-right'))?>
+			<?=$form->submit('add-new','Save & Add New',array('class'=>'ccm-button-v2-right'))?>
+			<?=$form->submit('save','Save',array('class'=>'ccm-button-v2-right primary'))?>
 			<?=$ih->button('Cancel', $this->action('colors_list'), 'left')?>
 		</div>
 	</form>

--- a/packages/automobiles/single_pages/dashboard/automobiles/misc/manufacturers/edit.php
+++ b/packages/automobiles/single_pages/dashboard/automobiles/misc/manufacturers/edit.php
@@ -13,7 +13,7 @@ $action = $is_new ? $this->action('manufacturers_add') : $this->action('manufact
 
 	<form method="post" action="<?=$action?>">
 		<?=$token?>
-		<?=$form->hidden('id', (int)$id); /* redundant, but simplifies processing */ ?>
+		<input type="hidden" id="id" name="id" value="<?= (int)$id?>" /><?php /* redundant, but simplifies processing */ /*manual hidden, since C5 overrides with post values */ ?>
 		
 		<div class="ccm-pane-body">
 
@@ -44,7 +44,9 @@ $action = $is_new ? $this->action('manufacturers_add') : $this->action('manufact
 		</div>
 		
 		<div class="ccm-pane-footer">
-			<?=$ih->submit('Save', false, 'right', 'primary')?>
+			<?=$form->submit('duplicate','Save & Duplicate',array('class'=>'ccm-button-v2-right'))?>
+			<?=$form->submit('add-new','Save & Add New',array('class'=>'ccm-button-v2-right'))?>
+			<?=$form->submit('save','Save',array('class'=>'ccm-button-v2-right primary'))?>
 			<?=$ih->button('Cancel', $this->action('manufacturers_list'), 'left')?>
 		</div>
 


### PR DESCRIPTION
Many people prefer to not have to go back to the list view and click again to add a new item. Additionally, for example in cars, you may have several cars of different years and you want to duplicate most of the info, but change a couple of fields. These changes add that functionality

NOTES: 
You have to use a manual hidden id field since C5's form helper overrides it with the post variable (submitting a pull request for a fix for this to the C5 core soon)
The buttons were changed to the form instead of interface button style since they needed different names. Formatting was left intact
