### PR TITLE
Move factory up into the parent class

### DIFF
--- a/packages/automobiles/libraries/crud_model.php
+++ b/packages/automobiles/libraries/crud_model.php
@@ -38,6 +38,15 @@ class BasicCRUDModel {
 		}
 	}
 	
+	//use this for one-off's to reduce a line of code -- e.g. BodyTypeModel::factory()->getAll()
+	//If you are using a version of php < 5.3.0, this needs to be overrided in each model like this:
+	//	public static function factory() {
+	//		return new BodyTypeModel;
+	//	}
+	public static function factory() {
+		return new static;
+	}
+	
 	public function getAll() {
 		$sql = "SELECT * FROM {$this->table} ORDER BY {$this->order}";
 		return $this->db->GetArray($sql);

--- a/packages/automobiles/models/body_type.php
+++ b/packages/automobiles/models/body_type.php
@@ -5,11 +5,6 @@ class BodyTypeModel extends SortableCRUDModel {
 	
 	protected $table = 'automobile_body_types';
 	
-	//use this for one-off's to reduce a line of code -- e.g. BodyTypeModel::factory()->getAll()
-	public static function factory() {
-		return new BodyTypeModel;
-	}
-	
 	public function getSelectOptions($header_item = array()) {
 		return $this->selectOptionsFromArray($this->getAll(), 'id', 'name', $header_item);
 	}

--- a/packages/automobiles/models/car.php
+++ b/packages/automobiles/models/car.php
@@ -6,11 +6,6 @@ class CarModel extends BasicCRUDModel {
 	protected $table = 'automobile_cars';
 	protected $order = 'name';
 	
-	//use this for one-off's to reduce a line of code -- e.g. CarModel::factory()->getAll()
-	public static function factory() {
-		return new CarModel;
-	}
-	
 	public function getById($id) {
 		$sql = "SELECT car.*, body_type.name AS body_type_name, manufacturer.name AS manufacturer_name"
 		     . " FROM {$this->table} car"

--- a/packages/automobiles/models/color.php
+++ b/packages/automobiles/models/color.php
@@ -6,11 +6,6 @@ class ColorModel extends BasicCRUDModel {
 	protected $table = 'automobile_colors';
 	protected $order = 'name';
 	
-	//use this for one-off's to reduce a line of code -- e.g. ColorModel::factory()->getAll()
-	public static function factory() {
-		return new ColorModel;
-	}
-	
 	//returns *all* color records, with an additional column called 'has'
 	// that denotes if the given car has the color or not
 	public function getAllWithCar($car_id) {

--- a/packages/automobiles/models/manufacturer.php
+++ b/packages/automobiles/models/manufacturer.php
@@ -6,11 +6,6 @@ class ManufacturerModel extends BasicCRUDModel {
 	protected $table = 'automobile_manufacturers';
 	protected $order = 'name';
 	
-	//use this for one-off's to reduce a line of code -- e.g. ManufacturerModel::factory()->getAll()
-	public static function factory() {
-		return new ManufacturerModel;
-	}
-	
 	public function getSelectOptions($header_item = array()) {
 		return $this->selectOptionsFromArray($this->getAll(), 'id', 'name', $header_item);
 	}


### PR DESCRIPTION
As I was porting one project from the old codebase to the new codebase, I realized that the factory would be able to be moved up into the parent model class, removing the need to add it to every model. 

The only time this couldn't happen is for people hosting on versions of php < 5.3, which is rare for most shared hosting these days. I added a note for this situation though to make the issue clear.
