### PR TITLE
added ability to set ID field name for display table

### DIFF
--- a/packages/automobiles/libraries/crud_display_table.php
+++ b/packages/automobiles/libraries/crud_display_table.php
@@ -19,6 +19,10 @@ class CrudDisplayTable {
 		$this->view =& $c5_view_object;
 	}
 	
+	public function setIDField($id_field){
+		$this->id_field_name = $id_field;
+	}
+	
 	public function addColumn($field, $label = '', $escape_output = true) {
 		$this->columns[$field] = array(
 			'label' => $label,


### PR DESCRIPTION
Ok, so another one (this time I think you may actually agree with me, since it's basic :smile: )

So, I prefer using clear id names (like c5 does), because it makes queries easier. I'm porting a project from using all `id` for my pks, and I realized the display table wasn't working. While there is a private id field... it can't be changed externally on a call by call basis.

Thus, this tweak, to be able to change the id field.
