### PR TITLE
set new record post to a generic id

### DIFF
--- a/packages/automobiles/libraries/crud_model.php
+++ b/packages/automobiles/libraries/crud_model.php
@@ -86,7 +86,7 @@ class BasicCRUDModel {
 	}
 	
 	protected function isNewRecord($post) {
-		$id = isset($post[$this->pkid]) ? intval($post[$this->pkid]) : 0;
+		$id = isset($post['id']) ? intval($post['id']) : 0;
 		return ($id == 0);
 	}
 	


### PR DESCRIPTION
And another quick one.

Since I assume you always use id as your pkid, I don't assume you've run into this...

If you leave this as just 'id', then everything in your controller can be left nice and generic as id, and the model can set the proper pkid, as it should. This one line forces you to change every instance of the $id in the edit class though, and the views, to the named pkid in the model. It would be better to leave this mostly generic, to keep things simple.

This one is far more up for discussion, but I wanted to present it as an option
