### PR TITLE
Add method to get column names in CRUD Model

### DIFF
--- a/packages/automobiles/libraries/crud_model.php
+++ b/packages/automobiles/libraries/crud_model.php
@@ -48,6 +48,18 @@ class BasicCRUDModel {
 		$vals = array((int)$id);
 		return $this->db->GetRow($sql, $vals);
 	}
+
+	public function getColumnNames() {
+		$sql = "DESCRIBE {$this->table}";
+		$descriptions = $this->db->getArray($sql);
+		unset($descriptions[0]); // Drop the ID field
+
+		foreach($descriptions as $desc) {
+			$columns[] = $desc['Field'];
+		}
+		
+		return $columns;
+	}
 	
 	public function exists($id) {
 		$sql = "SELECT COUNT(*) FROM {$this->table} WHERE {$this->pkid} = ?";


### PR DESCRIPTION
I couldn't find any documentation for C5 that allows one to easily get the column names from the DB, so I just added one to your CRUD model.

I found it useful to create dynamic data import methods, so I thought I would share. For example:

``` php
$colNames = $model->getColumnNames();

while(($row = fgetcsv($handle)) !== FALSE) {
    for($i=0; $i<count($colNames); $i++) {
        $dataArr[$colNames[$i]] = $row;
    }

    $allData[] = $dataArr;
}

$model->save($allData);
```

If this is already existing functionality, let me know, and I'll refactor my code. :D
